### PR TITLE
chore: add test plan to new PR template (NUL-1475)

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,10 @@
 
 Please include a summary of the change with relevant motivation and context
 
+## Test Plan
+
+Please include steps to test the change. Include screenshots if applicable.
+
 ## Linked Issues & PRs
 
 - resolves <insert-issue-link>


### PR DESCRIPTION
## Description

Adds a "Test Plan" section to the template for new PRs to encourage engineers to test and document their code changes.

Test Plan (meta test plan of the test plan :smiley:):
1. Create a new PR
2. Assert that the "Test Plan" section is included in the default template

## Linked Issues & PRs

- resolves <insert-issue-link>
- relates to <insert-pr-link>

[GitHub Issue Linking Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
